### PR TITLE
[CPL-7241] [Google Ads] Import report data for whole period, not for each day separately

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,19 @@
-# Description of change
-(write a short description here or paste a link to JIRA)
+<!-- Don't forget to set this PR title as: [{ticked_id}] {ticket_name} -->
 
-# QA steps
- - [ ] automated tests passing
- - [ ] manual qa steps passing
+[Ticket link](https://railsware.atlassian.net/browse/CPL-)
 
-# Risks
+### Problem/domain
 
-# Rollback steps
- - revert this branch
+### Tech changes
+
+### Product changes
+
+<!-- This section is optional -->
+
+### How to test
+
+<!-- Please ALWAYS fill in this section! It's vital for the proper holding of Test Fest. Add "N/A" if it's a non-testable change -->
+
+### How to deploy
+
+<!-- This section is optional -->

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -156,11 +156,13 @@ def create_core_stream_query(resource_name, selected_fields, last_pk_fetched, fi
     return core_query
 
 
-def create_report_query(resource_name, selected_fields, query_date):
+def create_report_query(resource_name, selected_fields, start_date, end_date):
 
     format_str = "%Y-%m-%d"
-    query_date = utils.strftime(query_date, format_str=format_str)
-    report_query = f"SELECT {','.join(selected_fields)} FROM {resource_name} WHERE segments.date = '{query_date}' {build_parameters()}"
+    formatted_start_date = utils.strftime(start_date, format_str=format_str)
+    formatted_end_date = utils.strftime(end_date, format_str=format_str)
+    fields = ",".join(selected_fields)
+    report_query = f"SELECT {fields} FROM {resource_name} WHERE segments.date BETWEEN '{formatted_start_date}' AND '{formatted_end_date}' {build_parameters()}"
 
     return report_query
 
@@ -660,7 +662,7 @@ class ReportStream(BaseStream):
             # Add inclusion metadata
             if self.behavior[report_field]:
                 inclusion = "available"
-                if transformed_field_name in ({"date"} | self.automatic_keys):
+                if transformed_field_name in self.automatic_keys:
                     inclusion = "automatic"
             else:
                 inclusion = "unsupported"
@@ -730,39 +732,38 @@ class ReportStream(BaseStream):
             cutoff = end_date.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=90)
             query_date = max(query_date, cutoff)
             if query_date == cutoff:
-                LOGGER.info(f"Stream: {stream_name} supports only 90 days of data. Setting query date to {utils.strftime(query_date, '%Y-%m-%d')}.")
+                LOGGER.info(
+                    f"Stream: {stream_name} supports only 90 days of data. "
+                    f"Setting start date to {utils.strftime(query_date, '%Y-%m-%d')}."
+                )
 
-        if selected_fields == {'segments.date'}:
-            raise Exception(f"Selected fields is currently limited to {', '.join(selected_fields)}. Please select at least one attribute and metric in order to replicate {stream_name}.")
+        query = create_report_query(resource_name, selected_fields, start_date=query_date, end_date=end_date)
+        LOGGER.info(
+            f"Requesting {stream_name} data for dates from "
+            f"{utils.strftime(query_date, '%Y-%m-%d')} to {utils.strftime(end_date, '%Y-%m-%d')}."
+        )
 
-        while query_date <= end_date:
-            query = create_report_query(resource_name, selected_fields, query_date)
-            LOGGER.info(f"Requesting {stream_name} data for {utils.strftime(query_date, '%Y-%m-%d')}.")
+        try:
+            response = make_request(gas, query, customer["customerId"], config)
+        except GoogleAdsException as err:
+            LOGGER.warning("Failed query: %s", query)
+            LOGGER.critical(str(err.failure.errors[0].message))
+            raise RuntimeError from None
 
-            try:
-                response = make_request(gas, query, customer["customerId"], config)
-            except GoogleAdsException as err:
-                LOGGER.warning("Failed query: %s", query)
-                LOGGER.critical(str(err.failure.errors[0].message))
-                raise RuntimeError from None
+        with Transformer() as transformer:
+            # Pages are fetched automatically while iterating through the response
+            for message in response:
+                json_message = google_message_to_json(message)
+                transformed_message = self.transform_keys(json_message)
+                record = transformer.transform(transformed_message, stream["schema"])
+                record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
 
+                singer.write_record(stream_name, record)
 
-            with Transformer() as transformer:
-                # Pages are fetched automatically while iterating through the response
-                for message in response:
-                    json_message = google_message_to_json(message)
-                    transformed_message = self.transform_keys(json_message)
-                    record = transformer.transform(transformed_message, stream["schema"])
-                    record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
+        new_bookmark_value = {replication_key: utils.strftime(query_date)}
+        singer.write_bookmark(state, stream["tap_stream_id"], customer["customerId"], new_bookmark_value)
 
-                    singer.write_record(stream_name, record)
-
-            new_bookmark_value = {replication_key: utils.strftime(query_date)}
-            singer.write_bookmark(state, stream["tap_stream_id"], customer["customerId"], new_bookmark_value)
-
-            singer.write_state(state)
-
-            query_date += timedelta(days=1)
+        singer.write_state(state)
 
 
 def initialize_core_streams(resource_schema):


### PR DESCRIPTION
<!-- Don't forget to set this PR title as: [{ticked_id}] {ticket_name} -->

[Ticket link](https://railsware.atlassian.net/browse/CPL-7178)

### Problem/domain

- Google Ads tap works slowly with reports. 
  - #issue Users will reach 9 minutes timeout if the period is about 1 month.
  - #dk it sends a separate request for each day
- #goal Get report data for whole period with single request

### Tech changes

- Update `create_report_query` to generate query for whole period. 
  - Use the `BETWEEN` operator instead of `=`
- Remove logic with increasing days and send a separate request for them
- Remove logic that `date` column is automatically selected for all reports
- Update PR template

### How to test

N/A (It will be tested in https://github.com/railsware/coupler-io/pull/1074)