### PR TITLE
[CPL-7242] Use Google Ads API version 11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.3.3',
+      version='1.3.4',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',
@@ -13,8 +13,8 @@ setup(name='tap-google-ads',
           'singer-python==5.12.2',
           'requests==2.26.0',
           'backoff==1.8.0',
-          'google-ads==15.0.0',
-          'protobuf==3.17.3',
+          'google-ads==18.1.0',
+          'protobuf==4.21.7',
           # Necessary to handle gRPC exceptions properly, documented
           # in an issue here: https://github.com/googleapis/python-api-core/issues/301
           'grpcio-status==1.44.0',

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -14,7 +14,7 @@ from . import report_definitions
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "v10"
+API_VERSION = "v11"
 
 API_PARAMETERS = {
     "omit_unselected_resource_names": "true"


### PR DESCRIPTION
<!-- Don't forget to set this PR title as: [{ticked_id}] {ticket_name} -->

[Ticket link](https://railsware.atlassian.net/browse/CPL-7242)

### Problem/domain

#dk Google Ads tap uses API version 10 which is already deprecated and its sunset date is January 2023. [Learn more](https://developers.google.com/google-ads/api/docs/sunset-dates)
#goal use API version 11

### Tech changes

- Update the default version for API
- Update dependencies 

### How to test

N/A (It will be tested in https://github.com/railsware/coupler-io/pull/1074)