### PR TITLE
[CPL-8626] Move Google Ads to the new repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-google-ads',
       py_modules=['tap_google_ads'],
       install_requires=[
           'singer-python==5.12.2',
-          'requests==2.26.0',
+          'requests>=2.26.0',
           'backoff==1.8.0',
           'google-ads==18.1.0',
           'protobuf==4.21.7',


### PR DESCRIPTION
<!-- Don't forget to set this PR title as: [{ticked_id}] {ticket_name} -->

[Ticket link](https://railsware.atlassian.net/browse/CPL-8626)

### Problem/domain

- #issue Dependency `requests==2.26.0` conflicts with `requests==2.28.2` used in our serverless codebase. 
  - `requests` is used here to catch `ReadTimeout` error, so we can use `2.28.2` version here as well

### Tech changes

- Use not strict version if `requests` dependency

### How to test

N/A