### PR TITLE
[CPL-13741]: Handle fetching reports for inactive account

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -766,7 +766,7 @@ class ReportStream(BaseStream):
         except GoogleAdsException as err:
             LOGGER.warning("Failed query: %s", query)
             LOGGER.critical(str(err.failure.errors[0].message))
-            raise RuntimeError from None
+            raise err
 
         with Transformer() as transformer:
             # Pages are fetched automatically while iterating through the response


### PR DESCRIPTION
<!-- Don't forget to set this PR title as: [{ticked_id}] {ticket_name} -->

[Ticket link](https://railsware.atlassian.net/browse/CPL-13741)

### Problem/domain
Handle usage of inactive account during fetching reports

### Tech changes
- Raise original `GoogleAdsException` instance in `ReportStream#sync` method -> handling `GoogleAdsException` is already done in `do_sync` function

### How to test
N/A
