### PR TITLE
[CPL-15619] Use one API version for schema discovery and streaming 

### DIFF
--- a/tap_google_ads/api_version.py
+++ b/tap_google_ads/api_version.py
@@ -1,0 +1,1 @@
+API_VERSION = "v15"

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -3,6 +3,7 @@ import sys
 
 import singer
 
+from tap_google_ads.api_version import API_VERSION
 from tap_google_ads.client import create_sdk_client
 from tap_google_ads.streams import initialize_core_streams
 from tap_google_ads.streams import initialize_reports
@@ -66,7 +67,7 @@ CATEGORY_MAP = {
 
 def get_api_objects(config):
     client = create_sdk_client(config)
-    gaf_service = client.get_service("GoogleAdsFieldService")
+    gaf_service = client.get_service("GoogleAdsFieldService", version=API_VERSION)
 
     query = "SELECT name, category, data_type, selectable, filterable, sortable, selectable_with, metrics, segments, is_repeated, type_url, enum_values, attribute_resources"
 

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -10,11 +10,11 @@ from google.ads.googleads.errors import GoogleAdsException
 from google.api_core.exceptions import ServerError, TooManyRequests
 from requests.exceptions import ReadTimeout
 import backoff
+
+from tap_google_ads.api_version import API_VERSION
 from . import report_definitions
 
 LOGGER = singer.get_logger()
-
-API_VERSION = "v15"
 
 API_PARAMETERS = {
     "omit_unselected_resource_names": "true"


### PR DESCRIPTION
[Ticket link](https://railsware.atlassian.net/browse/CPL-15619)

### Problem/domain

Use one API version for schema discovery and streaming to avoid UNRECOGNIZED_FIELD errors when the latest version of API has different set of fields than the requested version.

### Tech changes

Make sure that all `client.get_service` method invocations has `version` parameter specified.

### Product changes

No changes.

### How to test

No changes.

### How to deploy

No changes.
