### PR TITLE
[CPL-15914] Make the tap incremental again

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -475,7 +475,7 @@ class BaseStream:  # pylint: disable=too-many-instance-attributes
                         json_message = google_message_to_json(message)
                         transformed_message = self.transform_keys(json_message)
                         record = transformer.transform(transformed_message, stream["schema"], singer.metadata.to_map(stream_mdata))
-                        record = self.add_account_info(customer, record)
+                        record = self.add_account_name(customer, record)
 
                         singer.write_record(stream_name, record)
                         counter.increment()
@@ -502,10 +502,7 @@ class BaseStream:  # pylint: disable=too-many-instance-attributes
             state['bookmarks'].pop(stream["tap_stream_id"])
             singer.write_state(state)
 
-    def add_account_info(self, customer, record):
-        """Add account name and ID to the record"""
-
-        record["Account ID"] = customer["customerId"]
+    def add_account_name(self, customer, record):
         record["Account name"] = customer["customerName"]
 
         return record
@@ -765,7 +762,7 @@ class ReportStream(BaseStream):
                     transformed_message = self.transform_keys(json_message)
                     record = transformer.transform(transformed_message, stream["schema"])
                     record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
-                    record = self.add_account_info(customer, record)
+                    record = self.add_account_name(customer, record)
 
                     singer.write_record(stream_name, record)
 

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -485,7 +485,7 @@ class BaseStream:  # pylint: disable=too-many-instance-attributes
                         json_message = google_message_to_json(message)
                         transformed_message = self.transform_keys(json_message)
                         record = transformer.transform(transformed_message, stream["schema"], singer.metadata.to_map(stream_mdata))
-                        record = self.add_account_name(customer, record)
+                        record = self.add_account_info(customer, record)
 
                         singer.write_record(stream_name, record)
                         counter.increment()
@@ -512,9 +512,10 @@ class BaseStream:  # pylint: disable=too-many-instance-attributes
             state['bookmarks'].pop(stream["tap_stream_id"])
             singer.write_state(state)
 
-    def add_account_name(self, customer, record):
-        """Add account name to the record"""
+    def add_account_info(self, customer, record):
+        """Add account name and ID to the record"""
 
+        record["Account ID"] = customer["customerId"]
         record["Account name"] = customer["customerName"]
 
         return record
@@ -775,7 +776,7 @@ class ReportStream(BaseStream):
                 transformed_message = self.transform_keys(json_message)
                 record = transformer.transform(transformed_message, stream["schema"])
                 record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
-                record = self.add_account_name(customer, record)
+                record = self.add_account_info(customer, record)
 
                 singer.write_record(stream_name, record)
 
@@ -845,7 +846,7 @@ class OneDayResultsReportStream(ReportStream):
                     transformed_message = self.transform_keys(json_message)
                     record = transformer.transform(transformed_message, stream["schema"])
                     record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
-                    record = self.add_account_name(customer, record)
+                    record = self.add_account_info(customer, record)
 
                     singer.write_record(stream_name, record)
 

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -156,13 +156,11 @@ def create_core_stream_query(resource_name, selected_fields, last_pk_fetched, fi
     return core_query
 
 
-def create_report_query(resource_name, selected_fields, start_date, end_date):
+def create_report_query(resource_name, selected_fields, query_date):
 
     format_str = "%Y-%m-%d"
-    formatted_start_date = utils.strftime(start_date, format_str=format_str)
-    formatted_end_date = utils.strftime(end_date, format_str=format_str)
-    fields = ",".join(selected_fields)
-    report_query = f"SELECT {fields} FROM {resource_name} WHERE segments.date BETWEEN '{formatted_start_date}' AND '{formatted_end_date}' {build_parameters()}"
+    query_date = utils.strftime(query_date, format_str=format_str)
+    report_query = f"SELECT {','.join(selected_fields)} FROM {resource_name} WHERE segments.date = '{query_date}' {build_parameters()}"
 
     return report_query
 
@@ -673,7 +671,7 @@ class ReportStream(BaseStream):
             # Add inclusion metadata
             if self.behavior[report_field]:
                 inclusion = "available"
-                if transformed_field_name in self.automatic_keys:
+                if transformed_field_name in ({"date"} | self.automatic_keys):
                     inclusion = "automatic"
             else:
                 inclusion = "unsupported"
@@ -743,39 +741,40 @@ class ReportStream(BaseStream):
             cutoff = end_date.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=90)
             query_date = max(query_date, cutoff)
             if query_date == cutoff:
-                LOGGER.info(
-                    f"Stream: {stream_name} supports only 90 days of data. "
-                    f"Setting start date to {utils.strftime(query_date, '%Y-%m-%d')}."
-                )
+                LOGGER.info(f"Stream: {stream_name} supports only 90 days of data. Setting query date to {utils.strftime(query_date, '%Y-%m-%d')}.")
 
-        query = create_report_query(resource_name, selected_fields, start_date=query_date, end_date=end_date)
-        LOGGER.info(
-            f"Requesting {stream_name} data for dates from "
-            f"{utils.strftime(query_date, '%Y-%m-%d')} to {utils.strftime(end_date, '%Y-%m-%d')}."
-        )
+        if selected_fields == {'segments.date'}:
+            raise Exception(f"Selected fields is currently limited to {', '.join(selected_fields)}. Please select at least one attribute and metric in order to replicate {stream_name}.")
 
-        try:
-            response = make_request(gas, query, customer["customerId"], config)
-        except GoogleAdsException as err:
-            LOGGER.warning("Failed query: %s", query)
-            LOGGER.critical(str(err.failure.errors[0].message))
-            raise err
+        while query_date <= end_date:
+            query = create_report_query(resource_name, selected_fields, query_date)
+            LOGGER.info(f"Requesting {stream_name} data for {utils.strftime(query_date, '%Y-%m-%d')}.")
 
-        with Transformer() as transformer:
-            # Pages are fetched automatically while iterating through the response
-            for message in response:
-                json_message = google_message_to_json(message)
-                transformed_message = self.transform_keys(json_message)
-                record = transformer.transform(transformed_message, stream["schema"])
-                record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
-                record = self.add_account_info(customer, record)
+            try:
+                response = make_request(gas, query, customer["customerId"], config)
+            except GoogleAdsException as err:
+                LOGGER.warning("Failed query: %s", query)
+                LOGGER.critical(str(err.failure.errors[0].message))
+                raise err
 
-                singer.write_record(stream_name, record)
 
-        new_bookmark_value = {replication_key: utils.strftime(query_date)}
-        singer.write_bookmark(state, stream["tap_stream_id"], customer["customerId"], new_bookmark_value)
+            with Transformer() as transformer:
+                # Pages are fetched automatically while iterating through the response
+                for message in response:
+                    json_message = google_message_to_json(message)
+                    transformed_message = self.transform_keys(json_message)
+                    record = transformer.transform(transformed_message, stream["schema"])
+                    record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
+                    record = self.add_account_info(customer, record)
 
-        singer.write_state(state)
+                    singer.write_record(stream_name, record)
+
+            new_bookmark_value = {replication_key: utils.strftime(query_date)}
+            singer.write_bookmark(state, stream["tap_stream_id"], customer["customerId"], new_bookmark_value)
+
+            singer.write_state(state)
+
+            query_date += timedelta(days=1)
 
 
 def initialize_core_streams(resource_schema):

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -167,14 +167,6 @@ def create_report_query(resource_name, selected_fields, start_date, end_date):
     return report_query
 
 
-def create_one_day_report_query(resource_name, selected_fields, query_date):
-    format_str = "%Y-%m-%d"
-    query_date = utils.strftime(query_date, format_str=format_str)
-    report_query = f"SELECT {','.join(selected_fields)} FROM {resource_name} WHERE segments.date = '{query_date}' {build_parameters()}"
-
-    return report_query
-
-
 def generate_hash(record, metadata):
     metadata = singer.metadata.to_map(metadata)
     fields_to_hash = []
@@ -786,78 +778,6 @@ class ReportStream(BaseStream):
         singer.write_state(state)
 
 
-class OneDayResultsReportStream(ReportStream):
-    def sync(self, sdk_client, customer, stream, config, state, query_limit):
-        gas = sdk_client.get_service("GoogleAdsService", version=API_VERSION)
-        resource_name = self.google_ads_resource_names[0]
-        stream_name = stream["stream"]
-        stream_mdata = stream["metadata"]
-        selected_fields = get_selected_fields(stream_mdata)
-        replication_key = "date"
-        state = singer.set_currently_syncing(state, [stream_name, customer["customerId"]])
-        singer.write_state(state)
-
-        conversion_window = timedelta(
-            days=get_conversion_window(config)
-        )
-        conversion_window_date = utils.now().replace(hour=0, minute=0, second=0, microsecond=0) - conversion_window
-
-        bookmark_object = singer.get_bookmark(state, stream["tap_stream_id"], customer["customerId"], default={})
-
-        bookmark_value = bookmark_object.get(replication_key)
-
-        query_date = get_query_date(
-            start_date=config["start_date"],
-            bookmark=bookmark_value,
-            conversion_window_date=singer.utils.strftime(conversion_window_date)
-        )
-
-        end_date = config.get("end_date")
-        if end_date:
-            end_date = utils.strptime_to_utc(end_date)
-        else:
-            end_date = utils.now()
-
-        if stream_name in REPORTS_WITH_90_DAY_MAX:
-            cutoff = end_date.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=90)
-            query_date = max(query_date, cutoff)
-            if query_date == cutoff:
-                LOGGER.info(
-                    f"Stream: {stream_name} supports only 90 days of data. "
-                    f"Setting start date to {utils.strftime(query_date, '%Y-%m-%d')}."
-                )
-
-        while query_date <= end_date:
-            query = create_one_day_report_query(resource_name, selected_fields, query_date)
-            LOGGER.info(f"Requesting {stream_name} data for {utils.strftime(query_date, '%Y-%m-%d')}.")
-
-            try:
-                response = make_request(gas, query, customer["customerId"], config)
-            except GoogleAdsException as err:
-                LOGGER.warning("Failed query: %s", query)
-                LOGGER.critical(str(err.failure.errors[0].message))
-                raise RuntimeError from None
-
-
-            with Transformer() as transformer:
-                # Pages are fetched automatically while iterating through the response
-                for message in response:
-                    json_message = google_message_to_json(message)
-                    transformed_message = self.transform_keys(json_message)
-                    record = transformer.transform(transformed_message, stream["schema"])
-                    record["_sdc_record_hash"] = generate_hash(record, stream_mdata)
-                    record = self.add_account_info(customer, record)
-
-                    singer.write_record(stream_name, record)
-
-            new_bookmark_value = {replication_key: utils.strftime(query_date)}
-            singer.write_bookmark(state, stream["tap_stream_id"], customer["customerId"], new_bookmark_value)
-
-            singer.write_state(state)
-
-            query_date += timedelta(days=1)
-
-
 def initialize_core_streams(resource_schema):
     return {
         "accessible_bidding_strategies": BaseStream(
@@ -1118,7 +1038,7 @@ def initialize_reports(resource_schema):
                 "campaign_criterion_criterion_id",
             },
         ),
-        "click_performance_report": OneDayResultsReportStream(
+        "click_performance_report": ReportStream(
             report_definitions.CLICK_PERFORMANCE_REPORT_FIELDS,
             ["click_view"],
             resource_schema,


### PR DESCRIPTION
[Ticket link](https://railsware.atlassian.net/browse/CPL-15914)

### Problem/domain

Current version of tap-google-ads is not usable in the context of incremental fetching because it fetches the whole period in one request which is not always possible due to amount of data and timeouts. This PR reverts previous commits 662e82ce2a3c94ca460b90cd7d5ee4af0d2fb386 and b3f24eb060daeb1b5f3ef12b9e2c90a7e94f5f45 and adds ability to specify the period length via config file.

### Tech changes

### Product changes

1. Fetch data in one request if `split_by_period` config parameter is not provided.
2. Fetch data incrementally by `relativedelta` value provided as `split_by_period` config parameter. Any number of days, months, or years is supported.
3. Make `click_performance_report` run incrementally day by day only because Google Ads doesn't allow any other date aggregations on it.
4. When some bookmark is provided, change calculation of the start date to account for conversion window.
```
                  conversion
                    window
                    length
                      v
                   |<--->|
                   v     v
----------S--------Q-----B--------E-------------------> time
          ^        ^     ^        ^
          |        |     |        |
        start      |  bookmark   end   
        date       |             date
                   |
                 query          
                 start
                 date
```

### How to test

Regression testing of Google Ads source is required.

### How to deploy

No changes.