### PR TITLE
[CPL-16235] Fetch data by specified date columns only

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -726,7 +726,7 @@ class ReportStream(BaseStream):
             # Add inclusion metadata
             if self.behavior[report_field]:
                 inclusion = "available"
-                if transformed_field_name in ({"date"} | self.automatic_keys):
+                if transformed_field_name in self.automatic_keys:
                     inclusion = "automatic"
             else:
                 inclusion = "unsupported"


### PR DESCRIPTION
[Ticket link](https://railsware.atlassian.net/browse/CPL-16235)

### Problem/domain

Commits 2597485a4f1490992ee8dfeaecb419005d3c3de1 and d880663a6cdc69a1240cd0ada9320eb2011d7767 accidentally reverted to original tap-google-ads behaviour in which tap fetches all reports day-by-day ONLY no matter
whether `date` column is requested in the config or not.



### Tech changes

Do not include `date` column into query if it is not specified in the config.

### Product changes

The tap must fetch data by months if `month` column specified but `date` column is not.

The tap must fetch data by days if both `month` and `date` columns are specified.

### How to test

Create a Campaign Performance source with "Split data by periods" set to "Month".
Run the workflow.
Observe that the result contains data by each month, not day.

Regression testing of "Reports" group of Google Ads sources is required.

### How to deploy