### PR TITLE
[CPL-17111]: [Google Ads] Handle accounts with lack of permissions same as we handle inactive accounts

### DIFF
--- a/tap_google_ads/sync.py
+++ b/tap_google_ads/sync.py
@@ -9,7 +9,7 @@ LOGGER = singer.get_logger()
 DEFAULT_QUERY_LIMIT = 1000000
 
 CUSTOMER_ACCOUNT_NOT_ACTIVE_ERROR = "The customer account can't be accessed because it is not yet enabled or has been deactivated"
-
+USER_DOES_NOT_HAVE_ACCESS_TO_CUSTOMER_ACCOUNT_ERROR = "User doesn't have permission to access customer."
 
 def get_currently_syncing(state):
     currently_syncing = state.get("currently_syncing")
@@ -135,7 +135,8 @@ def do_sync(config, catalog, resource_schema, state):
             except GoogleAdsException as e:
                 no_raise = False
                 for error in e.failure.errors:
-                    if CUSTOMER_ACCOUNT_NOT_ACTIVE_ERROR in error.message:
+                    if (CUSTOMER_ACCOUNT_NOT_ACTIVE_ERROR in error.message
+                            or USER_DOES_NOT_HAVE_ACCESS_TO_CUSTOMER_ACCOUNT_ERROR in error.message):
                         LOGGER.warning(
                             f"The ad account with the name \"{customer['customerName']}\" "
                             "can't be accessed because it is not yet enabled or "

--- a/tap_google_ads/sync.py
+++ b/tap_google_ads/sync.py
@@ -73,6 +73,10 @@ def get_query_limit(config):
     except Exception:
         LOGGER.warning(f"The entered query limit is invalid; it will be set to the default query limit of {DEFAULT_QUERY_LIMIT}")
         return DEFAULT_QUERY_LIMIT
+def inactive_or_inaccessible_account(error):
+    message = error.message
+
+    return (CUSTOMER_ACCOUNT_NOT_ACTIVE_ERROR in message or USER_DOES_NOT_HAVE_ACCESS_TO_CUSTOMER_ACCOUNT_ERROR in message)
 
 def do_sync(config, catalog, resource_schema, state):
     # QA ADDED WORKAROUND [START]
@@ -135,8 +139,7 @@ def do_sync(config, catalog, resource_schema, state):
             except GoogleAdsException as e:
                 no_raise = False
                 for error in e.failure.errors:
-                    if (CUSTOMER_ACCOUNT_NOT_ACTIVE_ERROR in error.message
-                            or USER_DOES_NOT_HAVE_ACCESS_TO_CUSTOMER_ACCOUNT_ERROR in error.message):
+                    if inactive_or_inaccessible_account(error):
                         LOGGER.warning(
                             f"The ad account with the name \"{customer['customerName']}\" "
                             "can't be accessed because it is not yet enabled or "


### PR DESCRIPTION
<!-- Don't forget to set this PR title as: [{ticked_id}] {ticket_name} -->

[Ticket link](https://railsware.atlassian.net/browse/CPL-17111)

### Problem/domain
We should catch the error related to usage of inaccessible account 

### Tech changes
- Added `USER_DOES_NOT_HAVE_ACCESS_TO_CUSTOMER_ACCOUNT_ERROR` const
- Change `try-except` block in `do_sync` function

### How to test
N/A
