### PR TITLE
[CPL-19171] Make processing 20% faster by avoiding unnecessary conversion to JSON

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -9,7 +9,7 @@ import singer
 from dateutil.relativedelta import relativedelta
 from google.ads.googleads.errors import GoogleAdsException
 from google.api_core.exceptions import ServerError, TooManyRequests
-from google.protobuf.json_format import MessageToJson
+from google.protobuf.json_format import MessageToDict
 from requests.exceptions import ReadTimeout
 from singer import Transformer, metrics, utils
 from tap_google_ads.api_version import API_VERSION
@@ -258,14 +258,11 @@ def make_request(gas, query, customer_id, config=None):
 
 def google_message_to_json(message):
     """
-    The proto field name for `type` is `type_` which will
-    get stripped by the Transformer. So we replace all
-    instances of the key `"type_"` before `json.loads`ing it
+    The proto field name for `type` is `type_` which will be
+    renamed to `type` by the Transformer.
     """
 
-    json_string = MessageToJson(message, preserving_proto_field_name=True)
-    json_string = json_string.replace('"type_":', '"type":')
-    return json.loads(json_string)
+    return MessageToDict(message, preserving_proto_field_name=True)
 
 
 def filter_out_non_attribute_fields(fields):


### PR DESCRIPTION
[Ticket link](https://railsware.atlassian.net/browse/CPL-19171)

### Problem/domain

tap-google-ads works very slow and most of the work is spent in parsing/transforming/printing of Google Ads response.

Google Ads API for reports is not paginated, so the tap reads the whole response into memory in one go at the start of execution and then processes row by row in the loop that can take minutes.

For example, a configuration on "Ad group performance by country" with 155k in output runs 5 minutes in Staging and Production environments.

### Tech changes

Improve performance of Google Ads response processing by removing unnecessary conversion to and from JSON string, `Protobuf message -> JSON string -> Python dict` is replaced with `Protobuf message -> Python dict`.

Line https://github.com/railsware/tap-google-ads/blob/c4e99ac4bffc6b2def4b1d0391473ce3bc528b71/tap_google_ads/streams.py#L267 seems redundant because `type_` properties are renamed into `type` by line https://github.com/railsware/tap-google-ads/blob/c4e99ac4bffc6b2def4b1d0391473ce3bc528b71/tap_google_ads/streams.py#L441

Local testing shows 20% improvement. So this low-hanging optimization may cut 1 minute on the workflow mentioned above.

### Product changes

Make Google Ads source functions work 20% faster.

### How to test

1. Full regression of Google Ads source is required. Incremental and non incremental.
2. Pay attention to columns with name "type", for example in "Core data" -> "Ads" report.
3. Compare performance of source function executions with and without the changes.

### How to deploy

No changes.