### PR TITLE
[CPL-19909] Do not miss periods that contain start of conversion window

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -552,9 +552,9 @@ def get_date_periods(
     ) -> Iterator[tuple[datetime, datetime]]:
     for period in periods:
         period_start, period_end = map(utils.strptime_to_utc, period)
-        # Skip periods that are covered by the bookmark because the tap state
-        # and its bookmarks are opaque to the caller.
-        if query_date <= period_start:
+        # Skip periods that are fully covered by the bookmark because the tap
+        # state and its bookmarks are opaque to the caller.
+        if period_end >= query_date:
             yield period_start, period_end
 
 


### PR DESCRIPTION
[Ticket link](https://railsware.atlassian.net/browse/CPL-19909)

### Problem/domain

Fix the defect when no queries are made when periods from config are wider than conversion window.

In the following case, "Period 2" should be processed but was omitted by the coding mistake.
```
     Period 1      Period 2
 |--------------|----------------|
 v              v                v
-|--------------|--|------------||------->
                   ^            ^        t
                 bmark       bookmark
                 minus
                 window
```


### Tech changes

Fix the period filtering condition.

### Product changes

No changes.

### How to test

Test incremental runs of daily Google Ads.

### How to deploy

No changes.
