### PR TITLE
[CPL-20326] Bump singer-python version to align with Airbyte CDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-google-ads',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_google_ads'],
       install_requires=[
-          'singer-python@git+https://github.com/railsware/singer-python/@ea0489dcb73fcb19195eea50eeff9a13d6914e9a',
+          'singer-python@git+https://github.com/railsware/singer-python/@565fcb685e6a636c3ad21e421a0662da47757573',
           'requests>=2.26.0',
           'backoff~=2.2.1',
           'google-ads==25.1.0',


### PR DESCRIPTION
# Description of change
[Ticket link](https://railsware.atlassian.net/browse/CPL-20326)
We need to align `jsonschema` dependency with [Airbyte CDK](https://github.com/airbytehq/airbyte-python-cdk/blob/main/pyproject.toml) to be able to install it into the default resolve
This PR bumps `singer-python` version where this conflict is resolved
